### PR TITLE
fix: Update httpx/httpcore/h11 to resolve dependency conflict

### DIFF
--- a/requirements-all.txt
+++ b/requirements-all.txt
@@ -1,5 +1,5 @@
 alabaster==0.7.12
-anyio==3.7.1
+anyio==4.7.0
 attrs==23.1.0
 Babel==2.9.1
 certifi==2024.7.4
@@ -7,9 +7,9 @@ charset-normalizer==2.0.7
 colorama==0.4.4
 coverage==7.3.2
 docutils==0.17.1
-h11==0.16.0
-httpcore==0.15.0
-httpx==0.23.0
+h11==0.14.0
+httpcore==1.0.7
+httpx==0.28.1
 idna==3.7
 imagesize==1.3.0
 iniconfig==1.1.1


### PR DESCRIPTION
## Summary
Updates HTTP-related dependencies to resolve version conflicts:

- `h11`: 0.16.0 → 0.14.0
- `httpcore`: 0.15.0 → 1.0.7  
- `httpx`: 0.23.0 → 0.28.1
- `anyio`: 3.7.1 → 4.7.0

## Problem
The old versions had a conflict: `httpcore==0.15.0` requires `h11<0.13`, but `h11==0.16.0` was pinned, causing pip to fail:

```
ERROR: Cannot install -r sirix-python-client/requirements-all.txt (line 11) and h11==0.16.0 
because these package versions have conflicting dependencies.
```

## Test plan
- [ ] Verify pip install works without conflicts
- [ ] Run tests to ensure httpx API compatibility